### PR TITLE
Mutant damage2

### DIFF
--- a/Resources/Prototypes/Damage/containers.yml
+++ b/Resources/Prototypes/Damage/containers.yml
@@ -52,14 +52,3 @@
   id: ShadowHaze
   supportedTypes:
     - Heat
-
-# stalker change
-- type: damageContainer
-  id: Mutant
-  supportedGroups:
-    - Brute
-    - Burn
-    - Toxin
-    - Airloss
-    - Genetic
-    - Mutant

--- a/Resources/Prototypes/Damage/containers.yml
+++ b/Resources/Prototypes/Damage/containers.yml
@@ -52,3 +52,14 @@
   id: ShadowHaze
   supportedTypes:
     - Heat
+
+# stalker change
+- type: damageContainer
+  id: Mutant
+  supportedGroups:
+    - Brute
+    - Burn
+    - Toxin
+    - Airloss
+    - Genetic
+    - Mutant

--- a/Resources/Prototypes/Damage/groups.yml
+++ b/Resources/Prototypes/Damage/groups.yml
@@ -42,3 +42,10 @@
   name: damage-group-genetic
   damageTypes:
     - Cellular
+
+# this whole group is a stalker change
+- type: damageGroup
+  id: Mutant
+  name: damage-group-brute
+  damageTypes:
+    - Mutant

--- a/Resources/Prototypes/Damage/groups.yml
+++ b/Resources/Prototypes/Damage/groups.yml
@@ -42,10 +42,3 @@
   name: damage-group-genetic
   damageTypes:
     - Cellular
-
-# this whole group is a stalker change
-- type: damageGroup
-  id: Mutant
-  name: damage-group-brute
-  damageTypes:
-    - Mutant

--- a/Resources/Prototypes/_Stalker/Damage/containers.yml
+++ b/Resources/Prototypes/_Stalker/Damage/containers.yml
@@ -1,0 +1,9 @@
+- type: damageContainer
+  id: Mutant
+  supportedGroups:
+    - Brute
+    - Burn
+    - Toxin
+    - Airloss
+    - Genetic
+    - Mutant

--- a/Resources/Prototypes/_Stalker/Damage/groups.yml
+++ b/Resources/Prototypes/_Stalker/Damage/groups.yml
@@ -1,0 +1,5 @@
+- type: damageGroup
+  id: Mutant
+  name: damage-group-brute
+  damageTypes:
+    - Mutant

--- a/Resources/Prototypes/_Stalker/Damage/types.yml
+++ b/Resources/Prototypes/_Stalker/Damage/types.yml
@@ -9,3 +9,9 @@
   name: Psy
   armorCoefficientPrice: 1
   armorFlatPrice: 1
+
+- type: damageType
+  id: Mutant
+  name: Mutant
+  armorCoefficientPrice: 1
+  armorFlatPrice: 1

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/Boss/cuckold.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/Boss/cuckold.yml
@@ -93,7 +93,6 @@
           layer:
             - MobLayer
     - type: Damageable
-      damageContainer: Biological
       damageModifierSet: PseudogiantMutant
     - type: SlowOnDamage
       speedModifierThresholds:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/bush.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/bush.yml
@@ -10,7 +10,6 @@
         - id: RandomSpawnerBushStalker
           amount: 3
     - type: Damageable
-      damageContainer: Biological
       damageModifierSet: BushMutant
     - type: DamageStateVisuals
       states:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/rat.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/rat.yml
@@ -59,7 +59,6 @@
     baseWalkSpeed: 3.2
     baseSprintSpeed: 4
   - type: Damageable
-    damageContainer: Biological
     damageModifierSet: PathetictMutant
   - type: SlowOnDamage
     speedModifierThresholds:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/psidog.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/psidog.yml
@@ -133,7 +133,6 @@
         types:
           Slash: 6
     - type: Damageable
-      damageContainer: Biological
       damageModifierSet: CloneMutant
     - type: Destructible
       thresholds:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/snork.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/snork.yml
@@ -9,7 +9,6 @@
       spawned:
         - id: MutantPartSnorkFoot
     - type: Damageable
-      damageContainer: Biological
       damageModifierSet: SnorkMutant
     - type: DamageStateVisuals
       states:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/bloodsucker.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/bloodsucker.yml
@@ -20,7 +20,6 @@
         Dead:
           Base: dead
     - type: Damageable
-      damageContainer: Biological
       damageModifierSet: BloodsuckerMutant
     - type: Destructible
       thresholds:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/byurer.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/byurer.yml
@@ -17,7 +17,6 @@
       Dead:
         Base: dead
   - type: Damageable
-    damageContainer: Biological
     damageModifierSet: BuyurerMutant
   - type: MobThresholds
     thresholds:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/oracle.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/oracle.yml
@@ -9,7 +9,6 @@
       spawned:
         - id: MutantPartOraculeEye
     - type: Damageable
-      damageContainer: Biological
       damageModifierSet: MutantOracles
     - type: DamageStateVisuals
       states:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/pseudogiant.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/pseudogiant.yml
@@ -83,7 +83,6 @@
           layer:
             - MobLayer
     - type: Damageable
-      damageContainer: Biological
       damageModifierSet: PseudogiantMutant
     - type: SlowOnDamage
       speedModifierThresholds:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/zombie.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/zombie.yml
@@ -34,7 +34,6 @@
         Dead:
           Base: dead
     - type: Damageable
-      damageContainer: Biological
       damageModifierSet: MutantZombie
     - type: Bands
       band: Zombie

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T4/gosha.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T4/gosha.yml
@@ -19,7 +19,6 @@
       maximum: 580
     # Other
     - type: Damageable
-      damageContainer: Biological
       damageModifierSet: STMutatedGosha
     - type: DamageStateVisuals
       states:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/base.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/base.yml
@@ -84,7 +84,7 @@
           Bloodloss:
             -1
     - type: Damageable
-      damageContainer: Biological
+      damageContainer: Mutant
       damageModifierSet: DefaultMutant
     - type: AtmosExposed
     - type: Flammable

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/mutantsDamageModifySets.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/mutantsDamageModifySets.yml
@@ -9,6 +9,7 @@
     Cold: 3.5
     Caustic: 0.2
     Compression: 20
+    Mutant: 1
 
 - type: damageModifierSet
   id: DefaultMutant
@@ -25,6 +26,7 @@
     Caustic: 0.2
     Compression: 20 #to make boars die from fucking anoms
     Psy: 0
+    Mutant: 1
   flatReductions:
     Blunt: 5
     Slash: 5
@@ -44,6 +46,7 @@
     Caustic: 0
     Compression: 20 #to make boars die from fucking anoms
     Psy: 0
+    Mutant: 1
   flatReductions:
     Piercing: 2
     Blunt: 5
@@ -63,6 +66,7 @@
     Caustic: 0
     Compression: 20 #to make boars die from fucking anoms
     Psy: 0
+    Mutant: 1
   flatReductions:
     Blunt: 2
     Slash: 2
@@ -83,6 +87,7 @@
     Caustic: 0
     Compression: 20 #to make boars die from fucking anoms
     Psy: 0
+    Mutant: 1
   flatReductions:
     Blunt: 6
     Slash: 6
@@ -103,6 +108,7 @@
     Caustic: 0
     Compression: 20 #to make boars die from fucking anoms
     Psy: 0
+    Mutant: 1
   flatReductions:
     Blunt: 5
     Piercing: 10
@@ -122,6 +128,7 @@
     Caustic: 0
     Compression: 20 #to make boars die from fucking anoms
     Psy: 0
+    Mutant: 1
 
 - type: damageModifierSet
   id: MutantOracles
@@ -138,6 +145,7 @@
     Caustic: 0
     Compression: 0
     Psy: 0
+    Mutant: 1
   flatReductions:
     Blunt: 5
     Piercing: 10
@@ -157,6 +165,7 @@
     Caustic: 0
     Compression: 0
     Psy: 0
+    Mutant: 1
   flatReductions:
     Blunt: 5
     Piercing: 10
@@ -176,6 +185,7 @@
     Caustic: 0
     Compression: 0
     Psy: 0
+    Mutant: 1
   flatReductions:
     Blunt: 5
     Piercing: 12
@@ -195,6 +205,7 @@
     Caustic: 0
     Compression: 0
     Psy: 0
+    Mutant: 1
   flatReductions:
     Blunt: 5
     Piercing: 5


### PR DESCRIPTION
Сделал мутантам новый тип урона, работающий только на них. Так же убрал у мутантов DamageContainer: biological который не только мешал работе нового типа урона, но ещё и сам по себе был бесполезен, ибо та же херня прописана была в парентах, лул.