### PR TITLE
Job whitelist for sponsors

### DIFF
--- a/Content.Server/Players/JobWhitelist/JobWhitelistManager.cs
+++ b/Content.Server/Players/JobWhitelist/JobWhitelistManager.cs
@@ -14,7 +14,7 @@ using Serilog;
 
 namespace Content.Server.Players.JobWhitelist;
 
-public sealed class JobWhitelistManager : IPostInjectInit
+public sealed partial class JobWhitelistManager : IPostInjectInit // Stalker-Changes | Make partial clone for sponsors
 {
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly IServerDbManager _db = default!;

--- a/Content.Server/_Stalker/Players/JobWhitelistManager.Stalker.cs
+++ b/Content.Server/_Stalker/Players/JobWhitelistManager.Stalker.cs
@@ -1,0 +1,25 @@
+using Content.Shared.Roles;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+
+// ReSharper disable once CheckNamespace
+namespace Content.Server.Players.JobWhitelist;
+
+public sealed partial class JobWhitelistManager
+{
+    public void AddSponsorWhitelist(NetUserId userId, List<ProtoId<JobPrototype>> whitelist)
+    {
+        if (!_whitelists.TryGetValue(userId, out var whitelistSet)) 
+            return;
+        
+        foreach (var job in whitelist)
+        {
+            whitelistSet.Add(job);
+        }
+
+        if (!_player.TryGetSessionById(userId, out var session))
+            return;
+        
+        SendJobWhitelist(session);
+    }
+}

--- a/Content.Server/_Stalker/Sponsors/SponsorSystem.Jobs.cs
+++ b/Content.Server/_Stalker/Sponsors/SponsorSystem.Jobs.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using Content.Server.Players.JobWhitelist;
+using Content.Shared._Stalker.Sponsors;
+using Content.Shared.Roles;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Server._Stalker.Sponsors;
+
+public sealed partial class SponsorSystem
+{
+    [Dependency] private readonly JobWhitelistManager _jobWhitelist = default!;
+    
+    private Dictionary<Enum, List<ProtoId<JobPrototype>>> _whitelist = new();
+
+    private void InitializeJobs()
+    {
+        _prototype.PrototypesReloaded += ReloadPrototypes;
+        _sponsors.SponsorPlayerCached += ReloadWhitelist;
+        
+        EnumeratePrototypes();
+    }
+
+    private void ReloadPrototypes(PrototypesReloadedEventArgs args)
+    {
+        if (!args.WasModified<SponsorWhitelistPrototype>())
+            return;
+        
+        EnumeratePrototypes();
+    }
+
+    private void ReloadWhitelist(NetUserId userId)
+    {
+        if (!_sponsors.TryGetInfo(userId, out var info))
+            return;
+
+        if (!_whitelist.TryGetValue(info.Level, out var jobs))
+            return;
+
+        _jobWhitelist.AddSponsorWhitelist(userId, jobs);
+    }
+
+    private void EnumeratePrototypes()
+    {
+        var prototypes = _prototype.EnumeratePrototypes<SponsorWhitelistPrototype>();
+        
+        foreach (var prototype in prototypes)
+        {
+            var list = _whitelist.GetOrNew(prototype.Level);
+            list.AddRange(prototype.Jobs);
+        }
+    }
+}

--- a/Content.Server/_Stalker/Sponsors/SponsorSystem.cs
+++ b/Content.Server/_Stalker/Sponsors/SponsorSystem.cs
@@ -15,7 +15,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server._Stalker.Sponsors;
 
-public sealed class SponsorSystem : EntitySystem
+public sealed partial class SponsorSystem : EntitySystem
 {
     [Dependency] private readonly IConsoleHost _consoleHost = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -34,6 +34,8 @@ public sealed class SponsorSystem : EntitySystem
 
         // debug
         _consoleHost.RegisterCommand("st_list_sponsors", ListSponsors);
+        
+        InitializeJobs();
     }
 
     #region GiveLoadout

--- a/Content.Server/_Stalker/Sponsors/SponsorsManager.cs
+++ b/Content.Server/_Stalker/Sponsors/SponsorsManager.cs
@@ -28,6 +28,8 @@ public sealed class SponsorsManager
     private readonly HttpClient _httpClient = new();
     private readonly Dictionary<NetUserId, SponsorData> _cachedSponsors = new();
 
+    public event Action<NetUserId>? SponsorPlayerCached;
+
     private string _apiUrl = string.Empty;
     private string _apiKey = string.Empty;
     private bool _enabled;
@@ -199,6 +201,7 @@ public sealed class SponsorsManager
 
         var data = new SponsorData(level, e.UserId, isGiven, contrib);
         _cachedSponsors.Add(e.UserId, data);
+        SponsorPlayerCached?.Invoke(e.UserId);
 
         _sawmill.Debug($"{e.UserId} is sponsor now. UserId: {e.UserId}. Level: {Enum.GetName(data.Level)}:{(int)data.Level}");
     }

--- a/Content.Shared/_Stalker/Sponsors/SponsorWhitelistPrototype.cs
+++ b/Content.Shared/_Stalker/Sponsors/SponsorWhitelistPrototype.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Stalker.Sponsors;
+
+[Prototype("sponsorWhitelist")]
+public sealed class SponsorWhitelistPrototype : IPrototype
+{
+    [IdDataField] 
+    public string ID { get; private set; } = default!;
+    
+    [DataField]
+    public Enum Level = default!;
+    
+    [DataField]
+    public List<ProtoId<JobPrototype>> Jobs = new();
+}

--- a/Resources/Prototypes/_Stalker/_Sponsors/jobs.yml
+++ b/Resources/Prototypes/_Stalker/_Sponsors/jobs.yml
@@ -1,0 +1,6 @@
+# Sponsor level can be found in Content.Shared/_Stalker/Sponsors/SponsorInfo.cs
+#- type: sponsorWhitelist
+#  id: BackerJobsWhitelist
+#  level: enum.SponsorLevel.Backer
+#  jobs:
+#    - StalkerBandit


### PR DESCRIPTION

<!-- По всем вопросам обращайтесь в наш дискорд https://discord.gg/stalker14 -->

## Что я изменил
Теперь есть прототип для спонсоров, который позволяет автоматически выдавать спонсорам вайтлист на различные роли.
Прототип выглядит следующим образом:
```yml
- type: sponsorWhitelist
  id: BackerJobWhitelist
  level: enum.SponsorLevel.Backer # Это уровень спонсорки, бывает несколько, Bread, Backer, OMind, Pseudogiant
  jobs:
  - StalkerBandit
```

## Тех. часть
Я не придумал как сделать лучше, из-за порядка инициализации SponsorsManager я не стал его использовать(это невозможно ввиду более поздней подгрузки). Приходится дважды обновлять один дикт для каждого спонсора, т.к спонсорка подгружается позже, чем загружаются данные из бд по игроку, увы, как есть. Переписывать спонсорку я не готов, спасибо, не надо.

<!-- Проставить X — [X]: -->
## Убедитесь что вы проверили и согласны со следующим
- [X] Да, я запустил свой код и протестил что изменения работают
- [X] Да, я проверил что в консольном выводе клиента и сервера не появилось ошибок после моих изменений
- [X] Я согласен, что отправляя PR соглашаюсь на условия лицензии [Лицензия](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] Я проверил и подтверждаю, что все картинки и аудио файлы которые я добавил в PR принадлежат мне или находятся под открытой лицензией
