### PR TITLE
feat: No shade for status icons

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -81,6 +81,7 @@
           False: {visible: false}
   - type: StatusIcon
     bounds: -0.5,-0.5,0.5,0.5
+    isShaded: true
   - type: RotationVisuals
     defaultRotation: 90
     horizontalRotation: 90


### PR DESCRIPTION
## Что я изменил
Я ебал, мастер ветка не работает, кидайте нерабочую хуйню не в неё. Это должно исправить отображение статус иконок (включая группировки). Теперь они все шейдятся т.е. не видны за объектами и на них работает свет.

<!-- Проставить X — [X]: -->
## Убедитесь что вы проверили и согласны со следующим
- [x] Да, я запустил свой код и протестил что изменения работают
- [x] Да, я проверил что в консольном выводе клиента и сервера не появилось ошибок после моих изменений
- [x] Я согласен, что отправляя PR соглашаюсь на условия лицензии [Лицензия](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [x] Я проверил и подтверждаю, что все картинки и аудио файлы которые я добавил в PR принадлежат мне или находятся под открытой лицензией
