### PR TITLE
Add Stalker 14 licence to rsi validator

### DIFF
--- a/.github/rsi-schema.json
+++ b/.github/rsi-schema.json
@@ -83,7 +83,8 @@
             "CC-BY-NC-4.0",
             "CC-BY-NC-SA-3.0",
             "CC-BY-NC-SA-4.0",
-            "CC0-1.0"
+            "CC0-1.0",
+            "Stalker 14 license"
          ],
          "examples":[
             "CC-BY-SA-3.0"


### PR DESCRIPTION
<!-- По всем вопросам обращайтесь в наш дискорд https://discord.gg/stalker14 -->

## Что я изменил
<!-- Напишите что вы изменили или добавьте картинки -->
Недавно люди начали писать в графу license строку Stalker 14 licence, у оффов такой лицензии нету в enum для их тестов, что заставляет его указывать это как ошибку, хотя это вроде как не так (просто я в лицензиях не понимаю), но думаю такое изменение может быть полезно.

<!-- Проставить X — [X]: -->
## Убедитесь что вы проверили и согласны со следующим
- [x] Да, я запустил свой код и протестил что изменения работают
- [x] Да, я проверил что в консольном выводе клиента и сервера не появилось ошибок после моих изменений
- [x] Я согласен, что отправляя PR соглашаюсь на условия лицензии [Лицензия](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [x] Я проверил и подтверждаю, что все картинки и аудио файлы которые я добавил в PR принадлежат мне или находятся под открытой лицензией
