### PR TITLE
Monolith get their own damage container

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Player/playerMonolithDamageModifySets.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Player/playerMonolithDamageModifySets.yml
@@ -4,3 +4,15 @@
   coefficients:
     Radiation: 0
     Psy: 0
+
+- type: damageContainer
+  id: Monolith
+  supportedGroups:
+  - Burn
+  - Airloss
+  - Genetic
+  supportedTypes:
+  - Blunt
+  - Slash
+  - Piercing
+  - Compression

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/monolith.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/monolith.yml
@@ -35,8 +35,7 @@
         baseDecayRate: 0
       - type: PersonalDamageBlock
       - type: Damageable
-        damageContainer: Biological
-        damageModifierSet: STPlayerMonolithModifierSet
+        damageContainer: Monolith
       - type: BlockTackingHolyItems
       - type: TeethPull
         teethProto: ToothStalker


### PR DESCRIPTION
<!-- По всем вопросам обращайтесь в наш дискорд https://discord.gg/stalker14 -->
The modifier shit overwrites armor values so we're not using that shit anymore
## Что я изменил
<!-- Напишите что вы изменили или добавьте картинки -->
Monolith should now be affected by armor again and are immune to rads and psy just like before. I don't think I missed a damage type but let me know.
<!-- Проставить X — [X]: -->
## Убедитесь что вы проверили и согласны со следующим
- [X] Да, я запустил свой код и протестил что изменения работают
- [X] Да, я проверил что в консольном выводе клиента и сервера не появилось ошибок после моих изменений
- [X] Я согласен, что отправляя PR соглашаюсь на условия лицензии [Лицензия](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] Я проверил и подтверждаю, что все картинки и аудио файлы которые я добавил в PR принадлежат мне или находятся под открытой лицензией
